### PR TITLE
Implemented 9.3.3

### DIFF
--- a/internal/runtime/realm/builtin_function.go
+++ b/internal/runtime/realm/builtin_function.go
@@ -5,14 +5,17 @@ import (
 	"github.com/gojisvm/gojis/internal/runtime/lang"
 )
 
-func CreateBuiltinFunction(fn func(lang.Value, ...lang.Value) (lang.Value, errors.Error), realm *Realm, proto lang.Value, internalSlotsList ...lang.StringOrSymbol) {
+func CreateBuiltinFunction(fn func(lang.Value, ...lang.Value) (lang.Value, errors.Error), realm *Realm, proto lang.Value, internalSlotsList ...lang.StringOrSymbol) *lang.Object {
 	if realm == nil {
-		panic("TODO: get current realm record")
+		realm = CurrentRealm()
 	}
 	if proto == nil {
 		proto = realm.GetIntrinsicObject(IntrinsicNameFunctionPrototype)
 	}
 	fobj := lang.ObjectCreate(proto, internalSlotsList...)
 	fobj.Call = fn
-	panic("TODO: 9.3.3")
+	fobj.Realm = realm
+	fobj.Extensible = true
+	fobj.ScriptOrModule = lang.Null
+	return fobj
 }

--- a/internal/runtime/realm/realm.go
+++ b/internal/runtime/realm/realm.go
@@ -28,7 +28,10 @@ type Realm struct {
 	HostDefined lang.Value
 }
 
-func (*Realm) Type() lang.Type      { return lang.TypeInternal }
+// Type returns lang.TypeInternal.
+func (*Realm) Type() lang.Type { return lang.TypeInternal }
+
+// Value returns the Realm itself.
 func (r *Realm) Value() interface{} { return r }
 
 func CreateRealm() *Realm {

--- a/internal/runtime/realm/realm.go
+++ b/internal/runtime/realm/realm.go
@@ -1,6 +1,8 @@
 package realm
 
 import (
+	"sync/atomic"
+
 	"github.com/gojisvm/gojis/internal/runtime/binding"
 	"github.com/gojisvm/gojis/internal/runtime/errors"
 	"github.com/gojisvm/gojis/internal/runtime/lang"
@@ -12,6 +14,12 @@ const (
 	IntrinsicNameThrowTypeError    = "ThrowTypeError"
 )
 
+var (
+	currentRealm atomic.Value // holds *realm.Realm
+)
+
+func CurrentRealm() *Realm { return currentRealm.Load().(*Realm) }
+
 type Realm struct {
 	Intrinsics  *lang.Record
 	GlobalObj   lang.Value                   // Object or Undefined
@@ -19,6 +27,9 @@ type Realm struct {
 	TemplateMap map[interface{}]*lang.Object // Parse Node -> Object
 	HostDefined lang.Value
 }
+
+func (*Realm) Type() lang.Type      { return lang.TypeInternal }
+func (r *Realm) Value() interface{} { return r }
 
 func CreateRealm() *Realm {
 	r := new(Realm)

--- a/internal/runtime/realm/realm.go
+++ b/internal/runtime/realm/realm.go
@@ -18,6 +18,7 @@ var (
 	currentRealm atomic.Value // holds *realm.Realm
 )
 
+// CurrentRealm returns the current realm as used in the specification.
 func CurrentRealm() *Realm { return currentRealm.Load().(*Realm) }
 
 type Realm struct {


### PR DESCRIPTION
**Description**

Exported `Prototype` and `Extensible` of `lang.Object`, also implemented `CreateBuiltinFunction` as specified in 9.3.3.

Package `realm` has now a function `CurrentRealm` which returns the current realm. `CurrentRealm` is safe for concurrent use.

Closes #3
