### PR TITLE
Add test.v flag in golden_test #44

### DIFF
--- a/test/golden/golden_test.go
+++ b/test/golden/golden_test.go
@@ -1,10 +1,17 @@
 package golden_test
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/gojisvm/gojis/test/golden"
 )
+
+func init() {
+	if !flag.Parsed() {
+		flag.Set("test.v", "false")
+	}
+}
 
 func TestEqual(t *testing.T) {
 	golden.Equal(t, "Equal", []byte("This is the expected content.\n"))


### PR DESCRIPTION
**Description**

A clear and concise description of this pull request.

Closes #44 
I added `flag.Set(“test.v”, “false”)` following this article.
https://github.com/koding/multiconfig/issues/41#issuecomment-284425459