### PR TITLE
Add Go 1.13.x to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: go
 # responsibility to keep their compiler up to date.
 go:
   - 1.12.x
+  - 1.13.x
   - tip
 go_import_path: github.com/gojisvm/gojis
 


### PR DESCRIPTION
**Description**

Execute CI jobs on go 1.13 in addition to tip and 1.12.

This requires Go 1.13 to have an actual release (not just an RC)
