### PR TITLE
Test262 parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	github.com/tinylib/msgp v1.1.0 // indirect
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 	zombiezen.com/go/capnproto2 v2.17.0+incompatible
 )

--- a/tools/test262/doc.go
+++ b/tools/test262/doc.go
@@ -1,0 +1,5 @@
+// Package test262 provides helper tools to extract metadata from Test262 files.
+// Each test file may define metadata that describe additional
+// requirements. This information is delimited by the token
+// sequence /*--- and ---*/ and is structured as YAML.
+package test262

--- a/tools/test262/expectation.go
+++ b/tools/test262/expectation.go
@@ -1,0 +1,47 @@
+package test262
+
+type Phase uint8
+
+const (
+	PhaseUnknown Phase = iota
+	PhaseParse
+	PhaseEarly
+	PhaseResolution
+	PhaseRuntime
+)
+
+// Expectation contains all information that were
+// included in the metadata of a Test262-testcase.
+type Expectation struct {
+	Negative Negative
+	Includes []string
+	Flags    Flag
+	Locale   []string
+}
+
+type Negative struct {
+	Phase Phase
+	Type  string
+}
+
+type Flag uint16
+
+const (
+	FlagUnknown Flag = 1 << iota
+	FlagOnlyStrict
+	FlagNoStrict
+	FlagModule
+	FlagRaw
+	FlagAsync
+	FlagGenerated
+	FlagCanBlockIsFalse
+	FlagCanBlockIsTrue
+)
+
+func (f *Flag) Set(flag Flag) {
+	*f |= flag
+}
+
+func (f Flag) IsSet(flag Flag) bool {
+	return f&flag == flag
+}

--- a/tools/test262/requirements.go
+++ b/tools/test262/requirements.go
@@ -1,47 +1,115 @@
 package test262
 
+// Phase represents the phase, that the test is expected to produce an error.
 type Phase uint8
 
 const (
+	// PhaseUnknown is the default value and can be interpreted as "not set".
 	PhaseUnknown Phase = iota
+	// PhaseParse indicates, that an error occurs while parsing the source text.
 	PhaseParse
+	// PhaseEarly indicates, that an error occurs prior to evaluation.
 	PhaseEarly
+	// PhaseResolution indicates, that an error occurs during module resolution.
 	PhaseResolution
+	// PhaseRuntime indicates, that an error occurs during evaluation.
 	PhaseRuntime
 )
 
-// Requirements contains all information that were
-// included in the metadata of a Test262-testcase.
+// Requirements contains all information that were included in the metadata of a
+// Test262-testcase.
 type Requirements struct {
+	// If a test configured with the negative attribute completes without
+	// throwing an exception, or if the name of the thrown exception's
+	// constructor does not match the specified constructor name, or if the
+	// error occurs at a phase that differs from the indicated phase, the test
+	// must be interpreted as "failing."
 	Negative Negative
+	// One or more files whose content must be evaluated in the test realm's
+	// global scope prior to test execution. These files are located within the
+	// harness/ directory of the Test262 project.
 	Includes []string
-	Flags    Flag
-	Locale   []string
+	// Flags are flags that specify the execution environment further.
+	Flags Flag
+	// Locale allows tests to declare explicit information regarding locale
+	// specificity. Its value is an array of one or more valid language tags or
+	// subtags.
+	Locale []string
 }
 
+// Negative indicates, that these tests are expected to generate an uncaught
+// exception. The Phase and Type specify, when and what error is expected.
 type Negative struct {
+	// Phase is the stage of the test interpretation process that the error is
+	// expected to be produced.
 	Phase Phase
-	Type  string
+	// Type is the name of the constructor of the expected error.
+	Type string
 }
 
+// Flag effectively is a bitmask with 16 bits.
 type Flag uint16
 
 const (
+	// FlagUnknown is the default value and can be interpreted as "not set".
 	FlagUnknown Flag = 1 << iota
+	// FlagOnlyStrict indicates that the test must be executed just once, in
+	// strict mode, only.
 	FlagOnlyStrict
+	// FlagNoStrict indicates, that the test must be executed just once, in
+	// non-strict mode, only.
 	FlagNoStrict
+	// FlagModule indicates, that the test source code must be interpreted as
+	// module code. In addition, this flag negates the default requirement to
+	// execute the test both in strict mode and in non-strict mode. In other
+	// words, the transformation described by the section titled "Strict Mode"
+	// must not be applied to these tests.
 	FlagModule
+	// FlagRaw indicates, that the test source code must not be modified in any
+	// way, and the test must be executed just once (in non-strict mode, only).
 	FlagRaw
+	// FlagAsync indicates, that the file harness/doneprintHandle.js must be
+	// evaluated in the test realm's global scope prior to test execution. The
+	// test must not be considered complete until the implementation-defined
+	// print function has been invoked or some length of time has passed without
+	// any such invocation. In the event of a passing test run, this function
+	// will be invoked with the string 'Test262:AsyncTestComplete'. If invoked
+	// with a string that is prefixed with the character sequence
+	// Test262:AsyncTestFailure:, the test must be interpreted as failed. The
+	// implementation is free to select an appropriate length of time to wait
+	// before considering the test "timed out" and failing.
 	FlagAsync
+	// FlagGenerated indicates, that the test file was created procedurally
+	// using the project's test generation tool. This flag is specified for
+	// informational purposes only and has no bearing on how the test should be
+	// interpreted.
 	FlagGenerated
+	// FlagCanBlockIsFalse indicates, that the test file should only be run when
+	// the [[CanBlock]] property of the Agent Record executing the file is
+	// false.
 	FlagCanBlockIsFalse
+	// FlagCanBlockIsTrue indicates, that the test file should only be run when
+	// the [[CanBlock]] property of the Agent Record executing the file is true.
 	FlagCanBlockIsTrue
 )
 
+// Set sets all flags that are set in the given flag, in this flag.
+//
+//  f := new(Flag)
+//  f.Set(FlagModule)
+//  f.Set(FlagAsync)
+//  f == FlagModule | FlagAsync // true
 func (f *Flag) Set(flag Flag) {
 	*f |= flag
 }
 
+// IsSet determines if this flag contains all flags set in the given flag.
+//
+//	f := new(Flag)
+//	f.Set(FlagModule)
+//	f.Set(FlagAsync)
+//	f.IsSet(FlagModule) // true
+//	f.IsSet(FlagRaw)    // false
 func (f Flag) IsSet(flag Flag) bool {
 	return f&flag == flag
 }

--- a/tools/test262/requirements.go
+++ b/tools/test262/requirements.go
@@ -10,9 +10,9 @@ const (
 	PhaseRuntime
 )
 
-// Expectation contains all information that were
+// Requirements contains all information that were
 // included in the metadata of a Test262-testcase.
-type Expectation struct {
+type Requirements struct {
 	Negative Negative
 	Includes []string
 	Flags    Flag

--- a/tools/test262/test262.go
+++ b/tools/test262/test262.go
@@ -1,0 +1,123 @@
+package test262
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+type sentinel string
+
+func (s sentinel) Error() string { return string(s) }
+
+const (
+	// ErrNoTest262Metadata indicates, that a file that was attempted to parse,
+	// did not contain a Test262-Metadata header.
+	//
+	// To see the structure of a test metadata header, please see
+	// https://github.com/tc39/test262/blob/master/INTERPRETING.md
+	ErrNoTest262Metadata = sentinel("File does not contain a Test262-Metadata header")
+)
+
+var (
+	magicHeader = []byte("/*---")
+	magicFooter = []byte("---*/")
+)
+
+type metadata struct {
+	Negative struct {
+		Phase   string `yaml:"phase"`
+		ErrType string `yaml:"type"`
+	} `yaml:"negative"`
+	Includes []string `yaml:"includes"`
+	Flags    []string `yaml:"flags"`
+	Locale   []string `yaml:"locale"`
+}
+
+func ParseHeader(r io.Reader) (Expectation, error) {
+	content, err := ioutil.ReadAll(r) // files are small, so this should be fine
+	if err != nil {
+		return Expectation{}, fmt.Errorf("read data source: %v", err)
+	}
+
+	meta, err := parseMetadata(content)
+	if err != nil {
+		return Expectation{}, fmt.Errorf("parse metadata: %v", err)
+	}
+
+	flags := new(Flag)
+	for _, f := range meta.Flags {
+		flags.Set(toFlag(f))
+	}
+
+	exp := Expectation{
+		Negative: Negative{
+			Phase: toPhase(meta.Negative.Phase),
+			Type:  meta.Negative.ErrType,
+		},
+		Includes: meta.Includes,
+		Flags:    *flags,
+		Locale:   meta.Locale,
+	}
+
+	return exp, nil
+}
+
+func parseMetadata(data []byte) (md metadata, err error) {
+	if !(bytes.Contains(data, magicHeader) &&
+		bytes.Contains(data, magicFooter)) {
+		return metadata{}, ErrNoTest262Metadata
+	}
+
+	yamlStart := bytes.Index(data, magicHeader) + len(magicHeader)
+	yamlEnd := bytes.Index(data, magicFooter)
+	yamlData := bytes.TrimSpace(data[yamlStart:yamlEnd])
+
+	err = yaml.Unmarshal(yamlData, &md)
+	if err != nil {
+		return metadata{}, fmt.Errorf("unmarshal yaml: %v", err)
+	}
+
+	return
+}
+
+func toPhase(phase string) Phase {
+	switch phase {
+	case "parse":
+		return PhaseParse
+	case "early":
+		return PhaseEarly
+	case "resolution":
+		return PhaseResolution
+	case "runtime":
+		return PhaseRuntime
+	default:
+		return PhaseUnknown
+	}
+}
+
+func toFlag(flag string) Flag {
+	switch flag {
+	case "onlyStrict":
+		return FlagOnlyStrict
+	case "noStrict":
+		return FlagNoStrict
+	case "module":
+		return FlagModule
+	case "raw":
+		return FlagRaw
+	case "async":
+		return FlagAsync
+	case "generated":
+		return FlagGenerated
+	case "CanBlockIsFalse":
+		return FlagCanBlockIsFalse
+	case "CanBlockIsTrue":
+		return FlagCanBlockIsTrue
+	default:
+		return FlagUnknown
+	}
+}

--- a/tools/test262/test262.go
+++ b/tools/test262/test262.go
@@ -37,15 +37,15 @@ type metadata struct {
 	Locale   []string `yaml:"locale"`
 }
 
-func ParseHeader(r io.Reader) (Expectation, error) {
+func ParseHeader(r io.Reader) (Requirements, error) {
 	content, err := ioutil.ReadAll(r) // files are small, so this should be fine
 	if err != nil {
-		return Expectation{}, fmt.Errorf("read data source: %v", err)
+		return Requirements{}, fmt.Errorf("read data source: %v", err)
 	}
 
 	meta, err := parseMetadata(content)
 	if err != nil {
-		return Expectation{}, fmt.Errorf("parse metadata: %v", err)
+		return Requirements{}, fmt.Errorf("parse metadata: %v", err)
 	}
 
 	flags := new(Flag)
@@ -53,7 +53,7 @@ func ParseHeader(r io.Reader) (Expectation, error) {
 		flags.Set(toFlag(f))
 	}
 
-	exp := Expectation{
+	exp := Requirements{
 		Negative: Negative{
 			Phase: toPhase(meta.Negative.Phase),
 			Type:  meta.Negative.ErrType,

--- a/tools/test262/test262.go
+++ b/tools/test262/test262.go
@@ -37,6 +37,10 @@ type metadata struct {
 	Locale   []string `yaml:"locale"`
 }
 
+// ParseHeader parses a Test262-Metadata-Header from the given reader and
+// returns a struct containing all values from the header. If the reader can be
+// fully read and the data contains a syntactical correct YAML document, err
+// will always be nil.
 func ParseHeader(r io.Reader) (Requirements, error) {
 	content, err := ioutil.ReadAll(r) // files are small, so this should be fine
 	if err != nil {

--- a/tools/test262/test262_test.go
+++ b/tools/test262/test262_test.go
@@ -11,17 +11,17 @@ import (
 func TestParseHeader(t *testing.T) {
 	tests := []struct {
 		file    string
-		want    Expectation
+		want    Requirements
 		wantErr bool
 	}{
 		{
 			"file000.js",
-			Expectation{},
+			Requirements{},
 			true,
 		},
 		{
 			"file001.js",
-			Expectation{
+			Requirements{
 				Negative: Negative{
 					Phase: PhaseRuntime,
 					Type:  "ReferenceError",
@@ -31,7 +31,7 @@ func TestParseHeader(t *testing.T) {
 		},
 		{
 			"file002.js",
-			Expectation{
+			Requirements{
 				Negative: Negative{
 					Phase: PhaseParse,
 					Type:  "SyntaxError",
@@ -41,7 +41,7 @@ func TestParseHeader(t *testing.T) {
 		},
 		{
 			"file003.js",
-			Expectation{
+			Requirements{
 				Negative: Negative{
 					Phase: PhaseResolution,
 					Type:  "ReferenceError",

--- a/tools/test262/test262_test.go
+++ b/tools/test262/test262_test.go
@@ -1,0 +1,124 @@
+package test262
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHeader(t *testing.T) {
+	tests := []struct {
+		file    string
+		want    Expectation
+		wantErr bool
+	}{
+		{
+			"file000.js",
+			Expectation{},
+			true,
+		},
+		{
+			"file001.js",
+			Expectation{
+				Negative: Negative{
+					Phase: PhaseRuntime,
+					Type:  "ReferenceError",
+				},
+			},
+			false,
+		},
+		{
+			"file002.js",
+			Expectation{
+				Negative: Negative{
+					Phase: PhaseParse,
+					Type:  "SyntaxError",
+				},
+			},
+			false,
+		},
+		{
+			"file003.js",
+			Expectation{
+				Negative: Negative{
+					Phase: PhaseResolution,
+					Type:  "ReferenceError",
+				},
+				Flags: FlagModule,
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			require := require.New(t)
+
+			file, err := os.Open(filepath.Join("testdata", tt.file))
+			require.NoError(err)
+
+			got, err := ParseHeader(file)
+			if tt.wantErr {
+				require.Error(err)
+			}
+			require.Equal(tt.want, got)
+		})
+	}
+}
+
+func Test_toPhase(t *testing.T) {
+	tests := []struct {
+		phase string
+		want  Phase
+	}{
+		{"parse", PhaseParse},
+		{"early", PhaseEarly},
+		{"resolution", PhaseResolution},
+		{"runtime", PhaseRuntime},
+		// negative tests
+		{"Runtime", PhaseUnknown},
+		{"parser", PhaseUnknown},
+		{"RUNTIME", PhaseUnknown},
+		{"PARSE", PhaseUnknown},
+		{"unknown", PhaseUnknown},
+		{"Unknown", PhaseUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.phase, func(t *testing.T) {
+			if got := toPhase(tt.phase); got != tt.want {
+				t.Errorf("toPhase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_toFlag(t *testing.T) {
+	tests := []struct {
+		flag string
+		want Flag
+	}{
+		{"onlyStrict", FlagOnlyStrict},
+		{"noStrict", FlagNoStrict},
+		{"module", FlagModule},
+		{"raw", FlagRaw},
+		{"async", FlagAsync},
+		{"generated", FlagGenerated},
+		{"CanBlockIsFalse", FlagCanBlockIsFalse},
+		{"CanBlockIsTrue", FlagCanBlockIsTrue},
+		// negative tests
+		{"canBlockIsFalse", FlagUnknown},
+		{"canBlockIsTrue", FlagUnknown},
+		{"Generated", FlagUnknown},
+		{"GENERATED", FlagUnknown},
+		{"OnlyStrict", FlagUnknown},
+		{"nostrict", FlagUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.flag, func(t *testing.T) {
+			if got := toFlag(tt.flag); got != tt.want {
+				t.Errorf("toFlag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/test262/testdata/file000.js
+++ b/tools/test262/testdata/file000.js
@@ -1,0 +1,1 @@
+// This file does not have a metadata comment.

--- a/tools/test262/testdata/file001.js
+++ b/tools/test262/testdata/file001.js
@@ -1,0 +1,6 @@
+/*---
+negative:
+  phase: runtime
+  type: ReferenceError
+---*/
+unresolvable;

--- a/tools/test262/testdata/file002.js
+++ b/tools/test262/testdata/file002.js
@@ -1,0 +1,7 @@
+/*---
+negative:
+  phase: parse
+  type: SyntaxError
+---*/
+$DONOTEVALUATE();
+var a\u2E2F;

--- a/tools/test262/testdata/file003.js
+++ b/tools/test262/testdata/file003.js
@@ -1,0 +1,10 @@
+/*---
+negative:
+  phase: resolution
+  type: ReferenceError
+flags: [module]
+---*/
+$DONOTEVALUATE();
+export {} from './instn-resolve-empty-export_FIXTURE.js';
+// instn-resolve-empty-export_FIXTURE.js contains only:
+// 0++;


### PR DESCRIPTION
**Description**

Implements a Test262 metadata helper for Test262 files, which have their test requirements information encoded as yaml header in the file that is to be executed.

Closes #59 
